### PR TITLE
fix: exit if the merge button is not found

### DIFF
--- a/merge-guard.js
+++ b/merge-guard.js
@@ -15,6 +15,11 @@
     return;
   }
 
+  // Exit if the merge button is not found
+  if (!document.querySelectorAll('.btn-group-merge button[type=submit]')[0]) {
+    return;
+  }
+
   function refresh() {
     var button = document.querySelectorAll('.btn-group-merge button[type=submit]')[0];
     var commits = document.querySelectorAll('.commit-message .message');


### PR DESCRIPTION
Exit the function if the merge button is not found in the DOM.